### PR TITLE
feat(cli): Add --from option to supply/override keyword values (#57)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -49,6 +49,13 @@ impl Cli {
                     .takes_value(false)
                     .requires("template"),
             )
+            .arg(
+                Arg::new("keywords")
+                .help("Key, value pairs to be replaced,\nYou can use this to skip user inputs,\nExample: 'name=spark, author=pwnxpl0it'")
+                .long("from")
+                .takes_value(true)
+                .requires("template")
+            )
             .subcommand(Command::new("init").about("Creates a template for the current directory"))
             .get_matches()
     }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -14,6 +14,18 @@ fn main() {
     let mut keywords = Keywords::init();
     keywords.extend(config.clone().get_keywords());
 
+    if args.is_present("keywords") {
+        let pairs = args.value_of("keywords").unwrap();
+        let keys: Vec<&str> = pairs.split(',').collect();
+        for key in keys {
+            let (keyword, value) = key.split_once('=').unwrap();
+            keywords.insert(
+                Keywords::from(keyword.trim(), None),
+                value.trim().to_string(),
+            );
+        }
+    }
+
     if args.subcommand_matches("init").is_some() {
         let dest = format!(
             "{}.toml",

--- a/src/core/funcs.rs
+++ b/src/core/funcs.rs
@@ -70,6 +70,12 @@ impl Fns {
     ) {
         if let Some(found) = Self::find(txt, keywords, re) {
             for (keyword_name, (keyword, function)) in found {
+                let final_keyword = Self::remove_fn_name(&keyword, function);
+                if keywords.contains_key(&final_keyword) {
+                    keywords.insert(keyword, keywords[&final_keyword].clone());
+                    continue;
+                }
+
                 if !json_data.is_null() && keyword_name.contains('.') {
                     if let Ok(value) = jq_rs::run(&keyword_name, &json_data.to_string()) {
                         // Remove quotes from the value
@@ -90,7 +96,7 @@ impl Fns {
                         }
                         _ => {
                             keywords.insert(keyword.clone(), value.clone());
-                            keywords.insert(Self::remove_fn_name(&keyword, function), value);
+                            keywords.insert(final_keyword, value);
                         }
                     }
                 }


### PR DESCRIPTION
### **Add `--from` Option to Supply/Override Keyword Values**  

#### **Overview**  
This PR introduces a `--from` CLI argument that allows users to provide keyword values directly when running the tool. This feature expands the keywords hashmap and ensures that predefined values are used instead of triggering functions like `:read`.  

#### **Usage Example**  
```sh
spark template --from="name=spark, author=pwnxpl0it, hackerman=yes"
```
With this, the specified keywords (`name`, `author`, `hackerman`) will be pre-set and won't require user input or function execution.  

#### **Key Changes**  
- Added support for `--from` to allow overriding keyword values via CLI.  
- Ensures functions like `:read` are skipped for supplied values.  
- Improves automation by reducing interactive prompts.  

#### **Why This is Useful**  
- Enables scripting and automation without manual input.  
- Prevents unintended function execution on keywords.  
- Provides a cleaner and more flexible way to handle template values.  

Closes #57. 🚀  
