### PR TITLE
🐛 fix: create dirs after keyword replacement

### DIFF
--- a/src/core/templates/mod.rs
+++ b/src/core/templates/mod.rs
@@ -107,11 +107,9 @@ impl Template {
     ) -> Result<String, String> {
         Fns::find_and_exec(&file.content, keywords, re, json_data);
         Fns::find_and_exec(&file.path, keywords, re, json_data);
-
-        let project = Self::handle_project_name(keywords, options, file)
-            .map_err(|e| format!("Error handling project name: {}", e))?;
-
-        Ok(project)
+        
+        Self::handle_project_name(keywords, options, file)
+            .map_err(|e| format!("Error handling project name: {}", e))
     }
 
     fn prepare_file_content(

--- a/src/core/templates/mod.rs
+++ b/src/core/templates/mod.rs
@@ -111,15 +111,6 @@ impl Template {
         let project = Self::handle_project_name(keywords, options, file)
             .map_err(|e| format!("Error handling project name: {}", e))?;
 
-        let dir_path = Path::new(&file.path)
-            .parent()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
-
-        if !dir_path.is_empty() {
-            create_dirs(&Keywords::replace_keywords(keywords, &dir_path));
-        }
-
         Ok(project)
     }
 
@@ -137,6 +128,13 @@ impl Template {
         } else {
             output
         };
+
+        if let Some(dir) = Path::new(&path).parent() {
+            let dir_str = dir.to_string_lossy();
+            if !dir_str.is_empty() {
+                create_dirs(&dir_str);
+            }
+        }
 
         Ok((path, final_output))
     }


### PR DESCRIPTION
## 🔍 Problem

Closes #64
Fixed on https://github.com/pwnxpl0it/spark/commit/2bc9a2b48fe0f268fd58b9ea72ff4196bc0f9e2d
`create_dirs` was called using the **raw, pre-replacement** file path (still containing `{{$PROJECTNAME}}`), and only for the first file in the loop. This created a directory literally named `{{$PROJECTNAME}}` instead of the actual project name, causing a panic when writing any file whose parent directory hadn't been properly created.

## ✅ Fix

- 🔀 Moved `create_dirs` into `prepare_file_content`, after keyword replacement, so the correct resolved path is used — for every file, not just the first.
- 🧹 Removed dead debug code in `write_content` (`reversed()` call, debug `println!`, commented-out sleep).

## 🧪 Tested With

Template containing `path = "{{$PROJECTNAME}}/Shablanga.md"` (capital letter in filename) — previously panicked, now works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the timing of output directory creation during file processing to align with file path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->