### PR TITLE
Add protocol-based output targets (stdout://, stderr://, file://)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ content = "✅ Generated {{$PROJECTNAME}}"
 > Windows drive-letter paths such as `C:\Users\foo` are **never** mis-parsed as
 > protocol URIs — the scheme detector requires more than one character before the
 > colon.
-
+>
 > [!NOTE]
 > All Spark templating (keyword replacement, JSON paths, Liquid) is applied
 > before the output is dispatched to the target.  `stdout://{{$TARGET}}` is not

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ By default, `[[files]].path` is a filesystem path. You can prefix the path with 
 | `stdout://`   | Write rendered content to **stdout**           |
 | `stderr://`   | Write rendered content to **stderr**           |
 
+Unrecognized schemes (e.g. `ftp://`) are not treated as protocol targets and fall back to plain filesystem output.
+
 ### Examples
 
 Print a rendered message to stdout instead of creating a file:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Spark is a powerful and flexible project initializer designed to simplify your w
 - [Supply/Override Values from CLI (`--from`) 🏗️](#supplyoverride-values-from-cli---from-️)
 - [Environment Variables ⚙️](#environment-variables-%EF%B8%8F)
 - [Template Options](#template-options)
+- [Output Targets 🎯](#output-targets-)
 - [Git Integration 🐙](#git-integration-)
 - [Example Templates](#example-templates)
   - [Neovim Plugin](#neovim-plugin)
@@ -234,6 +235,69 @@ Template options in spark provide a way to customize the project setup by allowi
 | project_root    | Set the project name to a constant value or ask for user input  | `project_root="new_project"`, `project_root="{{$PROJECTNAME}}"` |
 | use_liquid    | Enable/Disable Liquid templating in the template (enabled by default)     | `use_liquid=true` |
 | json_data    | Embed JSON in the template for `{{$.…}}` placeholders     | See [JSON Integration](#json-integration) |
+
+
+## Output Targets 🎯
+
+By default, `[[files]].path` is a filesystem path. You can prefix the path with a protocol scheme to redirect rendered output to a different sink.
+
+| Scheme        | Behaviour                                      |
+|---------------|------------------------------------------------|
+| *(no scheme)* | Write to the filesystem (unchanged behaviour)  |
+| `file://path` | Write to `path` on the filesystem (explicit)   |
+| `stdout://`   | Write rendered content to **stdout**           |
+| `stderr://`   | Write rendered content to **stderr**           |
+
+### Examples
+
+Print a rendered message to stdout instead of creating a file:
+
+```toml
+[[files]]
+path = "stdout://"
+content = "Hello {{$NAME}}!"
+```
+
+Send a warning to stderr:
+
+```toml
+[[files]]
+path = "stderr://"
+content = "warning: {{$MESSAGE}}"
+```
+
+Use `file://` for an explicit filesystem path:
+
+```toml
+[[files]]
+path = "file://src/main.rs"
+content = """
+fn main() {}
+"""
+```
+
+You can mix targets freely in one template:
+
+```toml
+[[files]]
+path = "src/main.rs"          # normal file
+content = "fn main() {}"
+
+[[files]]
+path = "stdout://"            # also print a summary to stdout
+content = "✅ Generated {{$PROJECTNAME}}"
+```
+
+> [!NOTE]
+> Windows drive-letter paths such as `C:\Users\foo` are **never** mis-parsed as
+> protocol URIs — the scheme detector requires more than one character before the
+> colon.
+
+> [!NOTE]
+> All Spark templating (keyword replacement, JSON paths, Liquid) is applied
+> before the output is dispatched to the target.  `stdout://{{$TARGET}}` is not
+> supported as a dynamic target selector; the protocol prefix must be a literal
+> string after all placeholder replacements.
 
 
 ## Git Integration 🐙

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -105,9 +105,7 @@ mod tests {
 
     #[test]
     fn default_config_path() {
-        let matches = Cli::app()
-            .try_get_matches_from(["spark", "demo"])
-            .unwrap();
+        let matches = Cli::app().try_get_matches_from(["spark", "demo"]).unwrap();
         assert_eq!(
             matches.value_of("config"),
             Some("~/.config/spark/config.toml")
@@ -116,9 +114,7 @@ mod tests {
 
     #[test]
     fn parses_init_subcommand() {
-        let matches = Cli::app()
-            .try_get_matches_from(["spark", "init"])
-            .unwrap();
+        let matches = Cli::app().try_get_matches_from(["spark", "init"]).unwrap();
         assert!(matches.subcommand_matches("init").is_some());
     }
 
@@ -185,8 +181,17 @@ mod tests {
             keywords.insert(format!("{{{{${}}}}}", k.trim()), v.trim().to_string());
         }
 
-        assert_eq!(keywords.get("{{$PROJECTNAME}}").map(String::as_str), Some("myapp"));
-        assert_eq!(keywords.get("{{$author}}").map(String::as_str), Some("alice"));
-        assert_eq!(keywords.get("{{$version}}").map(String::as_str), Some("1.0"));
+        assert_eq!(
+            keywords.get("{{$PROJECTNAME}}").map(String::as_str),
+            Some("myapp")
+        );
+        assert_eq!(
+            keywords.get("{{$author}}").map(String::as_str),
+            Some("alice")
+        );
+        assert_eq!(
+            keywords.get("{{$version}}").map(String::as_str),
+            Some("1.0")
+        );
     }
 }

--- a/src/core/funcs.rs
+++ b/src/core/funcs.rs
@@ -25,8 +25,8 @@ impl Fns {
         keywords: &HashMap<String, String>,
         re: &Regex,
     ) -> Option<IndexMap<String, (String, Self)>> {
-        //HACK: remove me 
-        println!("I got called for {}",txt);
+        //HACK: remove me
+        println!("I got called for {}", txt);
         let mut found = IndexMap::new();
         for cap in re.captures_iter(txt) {
             if let Some(key_match) = cap.get(0) {
@@ -216,7 +216,10 @@ mod tests {
             &serde_json::Value::Null,
         );
 
-        assert_eq!(keywords.get("{{$NAME:read}}").map(String::as_str), Some("spark"));
+        assert_eq!(
+            keywords.get("{{$NAME:read}}").map(String::as_str),
+            Some("spark")
+        );
     }
 
     #[test]

--- a/src/core/funcs.rs
+++ b/src/core/funcs.rs
@@ -25,8 +25,6 @@ impl Fns {
         keywords: &HashMap<String, String>,
         re: &Regex,
     ) -> Option<IndexMap<String, (String, Self)>> {
-        //HACK: remove me
-        println!("I got called for {}", txt);
         let mut found = IndexMap::new();
         for cap in re.captures_iter(txt) {
             if let Some(key_match) = cap.get(0) {

--- a/src/core/keywords.rs
+++ b/src/core/keywords.rs
@@ -98,10 +98,8 @@ mod tests {
         map.insert("{{$NAME}}".to_string(), "spark".to_string());
         map.insert("{{$AUTHOR}}".to_string(), "pwnxpl0it".to_string());
 
-        let result = Keywords::replace_keywords(
-            &map,
-            "Project {{$NAME}} by {{$AUTHOR}} ({{$NAME}})",
-        );
+        let result =
+            Keywords::replace_keywords(&map, "Project {{$NAME}} by {{$AUTHOR}} ({{$NAME}})");
         assert_eq!(result, "Project spark by pwnxpl0it (spark)");
     }
 

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1,7 +1,9 @@
 pub mod funcs;
 pub mod keywords;
+pub mod output_target;
 pub mod templates;
 mod utils;
+pub use output_target::OutputTarget;
 use serde::{Deserialize, Serialize};
 pub use templates::Options;
 

--- a/src/core/output_target.rs
+++ b/src/core/output_target.rs
@@ -1,0 +1,286 @@
+//! Output target abstraction for Spark.
+//!
+//! A [`File`](crate::File) path can now contain an explicit protocol scheme that
+//! redirects rendered output to a sink other than the filesystem:
+//!
+//! | Path value      | Behaviour                               |
+//! |-----------------|----------------------------------------|
+//! | `stdout://`     | Write rendered content to **stdout**   |
+//! | `stderr://`     | Write rendered content to **stderr**   |
+//! | `file://some/path` | Write to the filesystem path after `file://` |
+//! | anything else   | Write to the filesystem (unchanged behaviour) |
+//!
+//! ## Windows path safety
+//!
+//! `C:\path` and `C:/path` contain a single-character "scheme" (`C`).  The
+//! parser only recognises schemes that are longer than one character, so
+//! Windows drive letters are never mis-parsed as protocol targets.
+//!
+//! ## Adding new protocols
+//!
+//! Implement a new variant on [`OutputTarget`] and add the matching arm in
+//! [`OutputTarget::from_path`] and [`OutputTarget::write`].  No changes to
+//! the rendering pipeline are required.
+
+use colored::Colorize;
+use std::{
+    io::{self, Write},
+    path::PathBuf,
+};
+
+/// The sink to which rendered template output is directed.
+#[derive(Debug, PartialEq)]
+pub enum OutputTarget {
+    /// Write to a filesystem path (shell-expanded).
+    File(PathBuf),
+    /// Write to standard output.
+    Stdout,
+    /// Write to standard error.
+    Stderr,
+}
+
+impl OutputTarget {
+    /// Parse a template path value into an [`OutputTarget`].
+    ///
+    /// Recognised schemes:
+    /// - `stdout://` → [`OutputTarget::Stdout`]
+    /// - `stderr://` → [`OutputTarget::Stderr`]
+    /// - `file://<path>` → [`OutputTarget::File`] for `<path>`
+    ///
+    /// Everything else (including Windows drive-letter paths such as `C:\foo`)
+    /// is treated as a plain filesystem path.
+    pub fn from_path(path: &str) -> Self {
+        // Extract the scheme: the part before the first ':'.
+        // A scheme must be more than one character to avoid treating Windows
+        // drive letters (e.g. `C:`) as protocol identifiers.
+        if let Some(colon_pos) = path.find(':') {
+            let scheme = &path[..colon_pos];
+            if scheme.len() > 1 {
+                match scheme {
+                    "stdout" => return Self::Stdout,
+                    "stderr" => return Self::Stderr,
+                    "file" => {
+                        // Strip "file://" prefix; the rest is the filesystem path.
+                        let rest = path
+                            .strip_prefix("file://")
+                            .unwrap_or_else(|| path.strip_prefix("file:").unwrap_or(path));
+                        return Self::File(PathBuf::from(rest));
+                    }
+                    _ => {
+                        // Unknown scheme — fall through to plain file path so we
+                        // don't break unusual-but-valid paths.
+                    }
+                }
+            }
+        }
+
+        Self::File(PathBuf::from(path))
+    }
+
+    /// Write `content` to the target.
+    ///
+    /// For [`OutputTarget::File`] the path is shell-expanded (same behaviour
+    /// as the existing [`crate::utils::write_content`]).
+    pub fn write(&self, content: &str) -> std::io::Result<()> {
+        match self {
+            Self::Stdout => {
+                print!("{}", content);
+                io::stdout().flush()
+            }
+            Self::Stderr => {
+                eprint!("{}", content);
+                io::stderr().flush()
+            }
+            Self::File(path) => {
+                let path_str = path.to_string_lossy();
+                let expanded = match shellexpand::full(&path_str) {
+                    Ok(e) => e.to_string(),
+                    Err(_) => path_str.to_string(),
+                };
+                // Create parent directories if needed (mirrors the existing
+                // behaviour that was previously in `prepare_file_content`).
+                if let Some(parent) = std::path::Path::new(&expanded).parent() {
+                    let parent_str = parent.to_string_lossy();
+                    if !parent_str.is_empty() {
+                        if let Err(e) = std::fs::create_dir_all(parent) {
+                            eprintln!("{}: {}", "error".red(), e);
+                        }
+                    }
+                }
+                // Preserve the existing behaviour: replace the legacy
+                // `initPJNAME` sentinel with `{{$PROJECTNAME}}`.
+                std::fs::write(
+                    std::path::Path::new(&expanded),
+                    content.replace("initPJNAME", "{{$PROJECTNAME}}"),
+                )
+                .map(|_| {
+                    println!("{}: {}", "file written".blue(), expanded.bold().green());
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OutputTarget;
+    use std::path::PathBuf;
+
+    // ── from_path parsing ────────────────────────────────────────────────────
+
+    #[test]
+    fn stdout_scheme_yields_stdout_target() {
+        assert_eq!(OutputTarget::from_path("stdout://"), OutputTarget::Stdout);
+    }
+
+    #[test]
+    fn stderr_scheme_yields_stderr_target() {
+        assert_eq!(OutputTarget::from_path("stderr://"), OutputTarget::Stderr);
+    }
+
+    #[test]
+    fn file_scheme_strips_prefix() {
+        assert_eq!(
+            OutputTarget::from_path("file://some/path/file.txt"),
+            OutputTarget::File(PathBuf::from("some/path/file.txt"))
+        );
+    }
+
+    #[test]
+    fn file_scheme_without_double_slash() {
+        // "file:" without "//" should still strip the "file:" prefix.
+        assert_eq!(
+            OutputTarget::from_path("file:relative/path.txt"),
+            OutputTarget::File(PathBuf::from("relative/path.txt"))
+        );
+    }
+
+    #[test]
+    fn relative_path_yields_file_target() {
+        assert_eq!(
+            OutputTarget::from_path("src/main.rs"),
+            OutputTarget::File(PathBuf::from("src/main.rs"))
+        );
+    }
+
+    #[test]
+    fn absolute_unix_path_yields_file_target() {
+        assert_eq!(
+            OutputTarget::from_path("/usr/local/bin/spark"),
+            OutputTarget::File(PathBuf::from("/usr/local/bin/spark"))
+        );
+    }
+
+    #[test]
+    fn windows_drive_letter_is_not_a_scheme() {
+        // "C" is a single character before ':', so it must NOT be treated as a
+        // protocol scheme.
+        assert_eq!(
+            OutputTarget::from_path(r"C:\Users\foo\project"),
+            OutputTarget::File(PathBuf::from(r"C:\Users\foo\project"))
+        );
+        assert_eq!(
+            OutputTarget::from_path("C:/Users/foo/project"),
+            OutputTarget::File(PathBuf::from("C:/Users/foo/project"))
+        );
+    }
+
+    #[test]
+    fn unknown_multi_char_scheme_falls_back_to_file() {
+        // An unrecognised scheme keeps backward-compat by treating the whole
+        // string as a filesystem path.
+        assert_eq!(
+            OutputTarget::from_path("ftp://some/path"),
+            OutputTarget::File(PathBuf::from("ftp://some/path"))
+        );
+    }
+
+    #[test]
+    fn plain_filename_no_colon_is_file() {
+        assert_eq!(
+            OutputTarget::from_path("README.md"),
+            OutputTarget::File(PathBuf::from("README.md"))
+        );
+    }
+
+    // ── write behaviour ──────────────────────────────────────────────────────
+
+    #[test]
+    fn stdout_write_succeeds() {
+        // We cannot easily capture stdout in a unit test without additional
+        // dependencies; we simply verify the call does not error.
+        let result = OutputTarget::Stdout.write("hello from stdout\n");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn stderr_write_succeeds() {
+        let result = OutputTarget::Stderr.write("hello from stderr\n");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn file_write_creates_file_with_content() {
+        let dir = std::env::temp_dir().join("spark_test_output_target_file");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let file_path = dir.join("out.txt");
+        let target = OutputTarget::File(file_path.clone());
+        target.write("hello spark").unwrap();
+
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "hello spark");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn file_write_replaces_init_pjname_placeholder() {
+        let dir = std::env::temp_dir().join("spark_test_output_target_pjname");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let file_path = dir.join("tpl.toml");
+        let target = OutputTarget::File(file_path.clone());
+        target.write("path = initPJNAME").unwrap();
+
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "path = {{$PROJECTNAME}}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── from_path + write round-trips ────────────────────────────────────────
+
+    #[test]
+    fn from_path_stdout_then_write_succeeds() {
+        let target = OutputTarget::from_path("stdout://");
+        assert_eq!(target, OutputTarget::Stdout);
+        assert!(target.write("roundtrip stdout\n").is_ok());
+    }
+
+    #[test]
+    fn from_path_stderr_then_write_succeeds() {
+        let target = OutputTarget::from_path("stderr://");
+        assert_eq!(target, OutputTarget::Stderr);
+        assert!(target.write("roundtrip stderr\n").is_ok());
+    }
+
+    #[test]
+    fn from_path_file_scheme_writes_to_disk() {
+        let dir = std::env::temp_dir().join("spark_test_output_target_file_scheme");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let file_path = dir.join("result.txt");
+        let raw = format!("file://{}", file_path.display());
+        let target = OutputTarget::from_path(&raw);
+
+        target.write("via file://").unwrap();
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "via file://");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/core/output_target.rs
+++ b/src/core/output_target.rs
@@ -57,8 +57,8 @@ impl OutputTarget {
             let scheme = &path[..colon_pos];
             if scheme.len() > 1 {
                 match scheme {
-                    "stdout" => return Self::Stdout,
-                    "stderr" => return Self::Stderr,
+                    "stdout" if path == "stdout://" => return Self::Stdout,
+                    "stderr" if path == "stderr://" => return Self::Stderr,
                     "file" => {
                         // Strip "file://" prefix; the rest is the filesystem path.
                         let rest = path
@@ -84,12 +84,16 @@ impl OutputTarget {
     pub fn write(&self, content: &str) -> std::io::Result<()> {
         match self {
             Self::Stdout => {
-                print!("{}", content);
-                io::stdout().flush()
+                let stdout = io::stdout();
+                let mut handle = stdout.lock();
+                handle.write_all(content.as_bytes())?;
+                handle.flush()
             }
             Self::Stderr => {
-                eprint!("{}", content);
-                io::stderr().flush()
+                let stderr = io::stderr();
+                let mut handle = stderr.lock();
+                handle.write_all(content.as_bytes())?;
+                handle.flush()
             }
             Self::File(path) => {
                 let path_str = path.to_string_lossy();
@@ -136,6 +140,44 @@ mod tests {
     #[test]
     fn stderr_scheme_yields_stderr_target() {
         assert_eq!(OutputTarget::from_path("stderr://"), OutputTarget::Stderr);
+    }
+
+    /// `stdout:report.txt` has a colon but is NOT the exact `stdout://`
+    /// sentinel — it must be treated as a plain filesystem path.
+    #[test]
+    fn stdout_with_suffix_is_file_not_stdout() {
+        assert_eq!(
+            OutputTarget::from_path("stdout:report.txt"),
+            OutputTarget::File(PathBuf::from("stdout:report.txt"))
+        );
+    }
+
+    /// `stdout://report.txt` looks like a URI with a path component —
+    /// it is not the exact `stdout://` sentinel and must fall back to File.
+    #[test]
+    fn stdout_with_uri_path_is_file_not_stdout() {
+        assert_eq!(
+            OutputTarget::from_path("stdout://report.txt"),
+            OutputTarget::File(PathBuf::from("stdout://report.txt"))
+        );
+    }
+
+    /// `stderr:report.txt` must fall back to File.
+    #[test]
+    fn stderr_with_suffix_is_file_not_stderr() {
+        assert_eq!(
+            OutputTarget::from_path("stderr:report.txt"),
+            OutputTarget::File(PathBuf::from("stderr:report.txt"))
+        );
+    }
+
+    /// `stderr://report.txt` must fall back to File.
+    #[test]
+    fn stderr_with_uri_path_is_file_not_stderr() {
+        assert_eq!(
+            OutputTarget::from_path("stderr://report.txt"),
+            OutputTarget::File(PathBuf::from("stderr://report.txt"))
+        );
     }
 
     #[test]

--- a/src/core/templates/mod.rs
+++ b/src/core/templates/mod.rs
@@ -1,3 +1,4 @@
+use crate::output_target::OutputTarget;
 use crate::utils::*;
 use crate::*;
 use colored::Colorize;
@@ -120,13 +121,6 @@ impl Template {
             output
         };
 
-        if let Some(dir) = Path::new(&path).parent() {
-            let dir_str = dir.to_string_lossy();
-            if !dir_str.is_empty() {
-                create_dirs(&dir_str);
-            }
-        }
-
         Ok((path, final_output))
     }
 
@@ -150,7 +144,9 @@ impl Template {
             let (path, final_output) =
                 Self::prepare_file_content(&file.content, &file.path, keywords, &options)?;
 
-            write_content(&path, &final_output).map_err(|e| format!("File write error: {}", e))?;
+            OutputTarget::from_path(&path)
+                .write(&final_output)
+                .map_err(|e| format!("Output write error: {}", e))?;
         }
 
         options.handle();

--- a/src/core/templates/mod.rs
+++ b/src/core/templates/mod.rs
@@ -329,7 +329,9 @@ mod tests {
     }
 
     #[test]
-    fn prepare_file_content_creates_parent_directories() {
+    fn output_target_file_write_creates_parent_directories() {
+        // Directory creation moved from prepare_file_content into
+        // OutputTarget::File::write – verify the end-to-end behaviour.
         let sub_dir = std::env::temp_dir().join("spark_test_prepare_dirs");
         let file_path = sub_dir.join("nested").join("test.txt");
         let _ = fs::remove_dir_all(&sub_dir);
@@ -352,7 +354,11 @@ mod tests {
 
         assert_eq!(path, file_path.to_string_lossy());
         assert_eq!(content, "hi");
+
+        // prepare_file_content no longer creates dirs; OutputTarget::write does.
+        OutputTarget::from_path(&path).write(&content).unwrap();
         assert!(file_path.parent().unwrap().is_dir());
+        assert!(file_path.is_file());
 
         let _ = fs::remove_dir_all(&sub_dir);
     }
@@ -722,6 +728,192 @@ Status: {{{{$.status[0]}}}}
             content,
             "Hello Trinity (7)\nStatus: embedded\n"
         );
+
+        let _ = fs::remove_dir_all(&out_dir);
+    }
+
+    // ── OutputTarget integration via extract() ───────────────────────────────
+
+    /// Calling extract() with `path = "stdout://"` must succeed and must NOT
+    /// write any file to the filesystem.
+    #[test]
+    fn extract_stdout_target_does_not_write_file() {
+        let mut template = Template {
+            info: None,
+            options: Some(Options {
+                git: false,
+                use_liquid: None,
+                json_data: None,
+                project_root: String::new(),
+            }),
+            files: Some(vec![File::new(
+                "stdout://".into(),
+                "Hello {{$GREETING}}".into(),
+            )]),
+        };
+
+        let mut keywords = HashMap::new();
+        keywords.insert("{{$GREETING}}".to_string(), "world".to_string());
+
+        // Must succeed – stdout is a valid target.
+        assert!(template.extract(&mut keywords).is_ok());
+
+        // Verify no file named "stdout:" or "stdout://" was created anywhere
+        // reachable from the current directory.
+        assert!(!std::path::Path::new("stdout:").exists());
+        assert!(!std::path::Path::new("stdout://").exists());
+    }
+
+    /// Calling extract() with `path = "stderr://"` must succeed without
+    /// creating a filesystem entry.
+    #[test]
+    fn extract_stderr_target_does_not_write_file() {
+        let mut template = Template {
+            info: None,
+            options: Some(Options {
+                git: false,
+                use_liquid: None,
+                json_data: None,
+                project_root: String::new(),
+            }),
+            files: Some(vec![File::new(
+                "stderr://".into(),
+                "error: {{$MSG}}".into(),
+            )]),
+        };
+
+        let mut keywords = HashMap::new();
+        keywords.insert("{{$MSG}}".to_string(), "something went wrong".to_string());
+
+        assert!(template.extract(&mut keywords).is_ok());
+        assert!(!std::path::Path::new("stderr:").exists());
+        assert!(!std::path::Path::new("stderr://").exists());
+    }
+
+    /// `file://` prefix is stripped and the content is written to the
+    /// filesystem path that follows.
+    #[test]
+    fn extract_file_scheme_writes_to_disk() {
+        let out_dir = std::env::temp_dir().join("spark_test_extract_file_scheme");
+        let _ = fs::remove_dir_all(&out_dir);
+        fs::create_dir_all(&out_dir).unwrap();
+
+        let file_path = out_dir.join("result.txt");
+        let raw_path = format!("file://{}", file_path.display());
+
+        let mut template = Template {
+            info: None,
+            options: Some(Options {
+                git: false,
+                use_liquid: None,
+                json_data: None,
+                project_root: String::new(),
+            }),
+            files: Some(vec![File::new(raw_path, "content via file://".into())]),
+        };
+
+        let mut keywords = HashMap::new();
+        template.extract(&mut keywords).unwrap();
+
+        assert!(file_path.is_file(), "file:// target must write to disk");
+        assert_eq!(
+            fs::read_to_string(&file_path).unwrap(),
+            "content via file://"
+        );
+
+        let _ = fs::remove_dir_all(&out_dir);
+    }
+
+    /// Keywords are replaced before dispatching to stdout://.
+    #[test]
+    fn extract_stdout_applies_keyword_replacement() {
+        // We cannot capture stdout in a unit test without additional deps,
+        // but we can verify that extract() returns Ok (not Err) when keywords
+        // are present, proving the replacement+dispatch pipeline ran to
+        // completion without errors.
+        let mut template = Template {
+            info: None,
+            options: Some(Options {
+                git: false,
+                use_liquid: None,
+                json_data: None,
+                project_root: String::new(),
+            }),
+            files: Some(vec![File::new(
+                "stdout://".into(),
+                "project: {{$NAME}} by {{$AUTHOR}}".into(),
+            )]),
+        };
+
+        let mut keywords = HashMap::new();
+        keywords.insert("{{$NAME}}".to_string(), "spark".to_string());
+        keywords.insert("{{$AUTHOR}}".to_string(), "pwnxpl0it".to_string());
+
+        assert!(template.extract(&mut keywords).is_ok());
+    }
+
+    /// Liquid is applied before dispatching to stderr://.
+    #[test]
+    fn extract_stderr_applies_liquid() {
+        let mut template = Template {
+            info: None,
+            options: Some(Options {
+                git: false,
+                use_liquid: Some(true),
+                json_data: None,
+                project_root: String::new(),
+            }),
+            files: Some(vec![File::new(
+                "stderr://".into(),
+                "{{ 'warn' | upcase }}".into(),
+            )]),
+        };
+
+        let mut keywords = HashMap::new();
+        assert!(template.extract(&mut keywords).is_ok());
+    }
+
+    /// A mix of protocol and filesystem targets in one template works
+    /// correctly: the filesystem file is written, stdout/stderr are not.
+    #[test]
+    fn extract_mixed_targets_file_and_stdout() {
+        let out_dir = std::env::temp_dir().join("spark_test_mixed_targets");
+        let _ = fs::remove_dir_all(&out_dir);
+        fs::create_dir_all(&out_dir).unwrap();
+
+        let file_path = out_dir.join("notes.txt");
+
+        let mut template = Template {
+            info: None,
+            options: Some(Options {
+                git: false,
+                use_liquid: None,
+                json_data: None,
+                project_root: String::new(),
+            }),
+            files: Some(vec![
+                File::new(
+                    file_path.to_string_lossy().to_string(),
+                    "filesystem content".into(),
+                ),
+                File::new("stdout://".into(), "stdout content".into()),
+                File::new("stderr://".into(), "stderr content".into()),
+            ]),
+        };
+
+        let mut keywords = HashMap::new();
+        template.extract(&mut keywords).unwrap();
+
+        // Filesystem file must exist with correct content.
+        assert!(file_path.is_file());
+        assert_eq!(
+            fs::read_to_string(&file_path).unwrap(),
+            "filesystem content"
+        );
+
+        // No spurious files for the protocol paths.
+        assert!(!std::path::Path::new("stdout:").exists());
+        assert!(!std::path::Path::new("stderr:").exists());
 
         let _ = fs::remove_dir_all(&out_dir);
     }

--- a/src/core/templates/mod.rs
+++ b/src/core/templates/mod.rs
@@ -215,7 +215,10 @@ mod tests {
             project_root: "proj".into(),
         });
 
-        assert_eq!(template.info.as_ref().unwrap().name.as_deref(), Some("demo"));
+        assert_eq!(
+            template.info.as_ref().unwrap().name.as_deref(),
+            Some("demo")
+        );
         assert_eq!(template.files.as_ref().unwrap().len(), 1);
         let options = template.dump_options().unwrap();
         assert!(options.git);
@@ -344,13 +347,9 @@ mod tests {
             project_root: String::new(),
         };
 
-        let (path, content) = Template::prepare_file_content(
-            "hi",
-            &file_path.to_string_lossy(),
-            &keywords,
-            &options,
-        )
-        .unwrap();
+        let (path, content) =
+            Template::prepare_file_content("hi", &file_path.to_string_lossy(), &keywords, &options)
+                .unwrap();
 
         assert_eq!(path, file_path.to_string_lossy());
         assert_eq!(content, "hi");
@@ -451,7 +450,10 @@ mod tests {
         );
         assert_eq!(fs::read_to_string(&second_file).unwrap(), "second core");
 
-        let unresolved = out_dir.join("myapp").join("{{$.module}}").join("second.txt");
+        let unresolved = out_dir
+            .join("myapp")
+            .join("{{$.module}}")
+            .join("second.txt");
         assert!(
             !unresolved.exists(),
             "wrote unresolved path placeholder: {:?}",
@@ -611,7 +613,8 @@ name = "Neo"
 path = "ignored.txt"
 content = "x"
 "#;
-        let template: Template = toml::from_str(toml_str).expect("toml with json_data should parse");
+        let template: Template =
+            toml::from_str(toml_str).expect("toml with json_data should parse");
         let options = template.options.expect("options present");
         let json = options.json_data.expect("json_data present");
         assert_eq!(json["user"]["name"], "Neo");
@@ -633,10 +636,7 @@ content = "x"
         let out_dir = std::env::temp_dir().join("spark_test_from_flag_projectname");
         let _ = fs::remove_dir_all(&out_dir);
 
-        let file_path = format!(
-            "{}/{{{{$PROJECTNAME}}}}/README.md",
-            out_dir.display()
-        );
+        let file_path = format!("{}/{{{{$PROJECTNAME}}}}/README.md", out_dir.display());
 
         let mut template = Template {
             info: None,
@@ -646,10 +646,7 @@ content = "x"
                 json_data: None,
                 project_root: "{{$PROJECTNAME}}".into(),
             }),
-            files: Some(vec![File::new(
-                file_path,
-                "# {{$PROJECTNAME}}".into(),
-            )]),
+            files: Some(vec![File::new(file_path, "# {{$PROJECTNAME}}".into())]),
         };
 
         // Pre-populate PROJECTNAME exactly as main() does when --from is given.
@@ -724,10 +721,7 @@ Status: {{{{$.status[0]}}}}
 
         let hello = out_dir.join("matrix").join("hello.txt");
         let content = fs::read_to_string(&hello).unwrap();
-        assert_eq!(
-            content,
-            "Hello Trinity (7)\nStatus: embedded\n"
-        );
+        assert_eq!(content, "Hello Trinity (7)\nStatus: embedded\n");
 
         let _ = fs::remove_dir_all(&out_dir);
     }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -2,6 +2,7 @@ use colored::*;
 use std::{fs, io, path::Path};
 use walkdir::WalkDir;
 
+#[allow(dead_code)]
 pub fn create_dirs(dir: &str) {
     match shellexpand::full(dir) {
         Ok(expanded) => {

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -83,8 +83,7 @@ mod tests {
         let file_path = std::env::temp_dir().join("spark_test_write_content.txt");
         let _ = fs::remove_file(&file_path);
 
-        write_content(&file_path, "Hello initPJNAME!")
-            .expect("write_content should succeed");
+        write_content(&file_path, "Hello initPJNAME!").expect("write_content should succeed");
 
         let read = fs::read_to_string(&file_path).expect("should read written file");
         assert_eq!(read, "Hello {{$PROJECTNAME}}!");


### PR DESCRIPTION
## Summary

Introduces a clean `OutputTarget` abstraction that lets `[[files]].path` redirect rendered content to sinks other than the filesystem.

## Motivation

Previously every `[[files]]` entry unconditionally wrote to disk. There was no way to print rendered output to stdout/stderr from a template without creating a file.

## Changes

**New module** `src/core/output_target.rs`:
- `OutputTarget` enum with `File(PathBuf)`, `Stdout`, and `Stderr` variants
- `OutputTarget::from_path(s)` — parses a protocol scheme prefix; falls back to `File` for plain paths and unknown schemes
- `OutputTarget::write(content)` — dispatches to the correct sink; `File` variant also handles parent-directory creation

**Rendering pipeline** (`src/core/templates/mod.rs`):
- One-line change in `extract()`: replaced `write_content()` with `OutputTarget::from_path(&path).write(&content)`
- Removed `create_dirs` call from `prepare_file_content` (responsibility moved into `OutputTarget::File::write`)

## Supported protocols

| Path value | Behaviour |
|---|---|
| `stdout://` | Write rendered content to stdout |
| `stderr://` | Write rendered content to stderr |
| `file://path` | Explicit filesystem write to `path` |
| *(no scheme)* | Unchanged filesystem behaviour |

## Backward compatibility

Existing templates require no changes. Windows drive-letter paths (`C:\foo`, `C:/foo`) are never mis-parsed as protocol URIs — the scheme detector requires more than one character before `:`.

## Tests

80 tests total, all passing. New coverage:
- Protocol parsing for all supported schemes
- Windows path safety
- Unix absolute and relative paths
- Unknown scheme fallback
- `extract()` integration tests: `stdout://`, `stderr://`, `file://`, mixed targets, keyword replacement through protocol targets, Liquid rendering through protocol targets

## Adding future protocols

Add a variant to `OutputTarget` and arms in `from_path`/`write`. No changes to the rendering pipeline are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rendered output can now be sent to filesystem paths, standard output, or standard error.
  * Supports explicit `file://`, `stdout://`, and `stderr://` targets, including mixed destinations in one operation.
  * Preserves Windows path handling, directory creation, shell expansion, and templating before output.
* **Documentation**
  * Added usage examples and guidance for configuring output targets, including Windows-specific path details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->