### PR TITLE
🔧 Improve template function resolution

### DIFF
--- a/src/core/funcs.rs
+++ b/src/core/funcs.rs
@@ -29,9 +29,23 @@ impl Fns {
         for cap in re.captures_iter(txt) {
             if let Some(key_match) = cap.get(0) {
                 let keyword = key_match.as_str().to_string();
+                // need to compare the overall arms not just checking if it's inserted or not
+                // if lhs function is the same as rhs function then no need to override in the IndexMap
                 if !keywords.contains_key(&keyword) {
                     let stripped_keyword = Keywords::strip(&keyword);
                     let parts: Vec<&str> = stripped_keyword.split(':').collect();
+                    if found.contains_key(parts[0]) {
+                        if let Some((_key, val)) = found.get(parts[0]) {
+                            if parts.len() == 2 {
+                                match (val, parts[1]) {
+                                    (&Fns::None, _) => {} // a user may later define the function in the template, but we catched None first so we need to update accordingly
+                                    _ => continue,
+                                }
+                            } else {
+                                continue;
+                            }
+                        }
+                    }
                     if parts.len() == 2 {
                         match parts[1].trim() {
                             "read" => {

--- a/src/core/templates/mod.rs
+++ b/src/core/templates/mod.rs
@@ -133,6 +133,15 @@ impl Template {
 
         for file in files {
             // Resolve functions/JSON in content and path before any keyword replacement.
+            // compiling content and path so we can we don't miss any keyword because a user might
+            // define function in one of them and expects the value to be replaced in both..
+            Fns::find_and_exec(
+                &(file.content.clone() + &file.path),
+                keywords,
+                &re,
+                &json_data,
+            );
+            // then we just call each one individually .. no reprocessing is done because we hold to our keywords hashmap
             Fns::find_and_exec(&file.content, keywords, &re, &json_data);
             Fns::find_and_exec(&file.path, keywords, &re, &json_data);
 


### PR DESCRIPTION
## Summary

Improve function resolution across template content and paths.

## Changes

- 🐛 Fix function precedence when the same keyword is found multiple times.
  - Allow an explicit function such as `KEYWORD:read` to upgrade a previously discovered `KEYWORD`.
  - Prevent an already-resolved function from being overwritten by a plain keyword.
- 🔧 Resolve functions using both template content and path before replacement.
  - Ensures keywords/functions defined in either location are discovered.
  - Reuse the resolved keyword map when processing content and paths individually.
  - Avoid unnecessary reprocessing.

## Testing

- Verified existing template processing behavior.
- Verified keyword/function resolution when occurrences appear in different parts of a template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of repeated function keywords to prevent duplicate entries.
  - Ensured more specific `:read` variants are retained when detected.
  - Template placeholders can now resolve definitions from both file content and paths.
  - Improved consistency when populating keywords across content and path processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->